### PR TITLE
feat: improve error handling

### DIFF
--- a/encoding/text/encode.go
+++ b/encoding/text/encode.go
@@ -49,10 +49,10 @@ func encode(ctx *fasthttp.RequestCtx, v any) error {
 			b = strconv.AppendFloat(ctx.Response.Body(), v, 'f', -1, 64)
 		case bool:
 			b = strconv.AppendBool(ctx.Response.Body(), v)
-		case error:
-			b = byteconv.Atob(v.Error())
 		case encoding.TextMarshaler:
 			b, err = v.MarshalText()
+		case error:
+			b = byteconv.Atob(v.Error())
 		case fmt.Stringer:
 			b = append(ctx.Response.Body(), v.String()...)
 		default:


### PR DESCRIPTION
- Ignore error's status code if explicitly wrapped with a status code.
- Return 404 on failure to decode path params.
- Text encoder uses `TextMarshaler` over `error`
- Remove redundant `StatusError` code.
- Return correct status code & message for server errors.