### PR TITLE
fix(encoding): take the first encoding supported

### DIFF
--- a/encoding/encode.go
+++ b/encoding/encode.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"context"
+	"strings"
 
 	"github.com/valyala/fasthttp"
 )
@@ -50,7 +51,13 @@ func RegisterEncoder[T EncoderConstraint](enc T, mime string, aliases ...string)
 
 // GetEncoder returns the response encoder for a given media type.
 func GetEncoder(mime string) ResponseEncoder {
-	return encoders[mime]
+	mimeParts := strings.Split(mime, ",")
+	for _, part := range mimeParts {
+		if enc, ok := encoders[part]; ok {
+			return enc
+		}
+	}
+	return nil
 }
 
 var encoders = map[string]ResponseEncoder{}

--- a/encoding/encode_test.go
+++ b/encoding/encode_test.go
@@ -68,3 +68,21 @@ func testRegisterEncoder[T encoding.EncoderConstraint](t *testing.T, dec T, cont
 		}
 	}
 }
+
+func TestGetEncoderMultipleContentTypes(t *testing.T) {
+	encFn := func(ctx *fasthttp.RequestCtx, v any) error {
+		return nil
+	}
+
+	encoding.RegisterEncoder(encFn, "application/xml")
+
+	enc := encoding.GetEncoder("text/html,application/xhtml+xml,application/xml")
+	if enc == nil {
+		t.Fatal("encoder not found")
+	}
+
+	enc = encoding.GetEncoder("application/xhtml+xml")
+	if enc != nil {
+		t.Fatal("encoder should not be found")
+	}
+}


### PR DESCRIPTION
Browsers submit multiple supported encodings, such as 
`Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`

By the time this function gets the accept header encoding, the part after the `;` has been removed, so we still need to split by `,` and find the first one we support.